### PR TITLE
comment markdown syntax

### DIFF
--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -30,7 +30,7 @@ import PromiseHash from './promise-hash';
     //   notAPromise: 4
     // }
   });
-  ````
+  ```
 
   If any of the `promises` given to `RSVP.hash` are rejected, the first promise
   that is rejected will be given as the reason to the rejection handler.


### PR DESCRIPTION
Wrong markdown code block syntax is breaking highlighting in editors.